### PR TITLE
Point header to py-why, not dowhy

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
         </li>
         <li><a href="news.html">News</a></li>
         <li><a href="resources.html">Resources</a></li>
-        <li><a href="https://github.com/py-why/dowhy" target="_blank">GitHub</a></li>
+        <li><a href="https://github.com/py-why" target="_blank">GitHub</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
For the PyWhy homepage, this is more appropriate.