### PR TITLE
add videos page to community section

### DIFF
--- a/_community_videos/00_talk_series.md
+++ b/_community_videos/00_talk_series.md
@@ -1,0 +1,12 @@
+---
+title: PyWhy Causality in Practice
+slug: pywhy-video
+layout: page
+description: >-
+  PyWhy community Discord and meeting schedule. 
+summary: >-
+
+  PyWhy Causality in Practice is a new talk series focusing on causality and machine learning, especially from a practical perspective. We'll have tutorials and presentations about PyWhy libraries but also talks by external speakers working on causal inference.
+
+
+---

--- a/_community_videos/01_talk_series.md
+++ b/_community_videos/01_talk_series.md
@@ -1,0 +1,17 @@
+---
+title: PyWhy Community Talk | LLMs for causal inference
+slug: pywhy-video
+layout: page
+description: >-
+  PyWhy community Discord and meeting schedule. 
+summary: >-
+  Check out our latest video from our PyWhy community meeting
+  <br>
+  <br>
+
+  <iframe width="800" height="450" src="https://www.youtube.com/embed/U9mJuUkhUzk?si=JHx2b2f0inFpwJ83" 
+  title="YouTube video player" frameborder="0" allow="accelerometer; autoplay;
+  clipboard-write; encrypted-media; gyroscope; picture-in-picture; 
+  web-share" allowfullscreen></iframe>
+
+---

--- a/_community_videos/01_talk_series.md
+++ b/_community_videos/01_talk_series.md
@@ -1,15 +1,12 @@
 ---
-title: PyWhy Causality in Practice | LLMs for causal inference
+title: LLMs for causal inference
 slug: pywhy-video
 layout: page
 description: >-
-  PyWhy community Discord and meeting schedule. 
+  PyWhy Causality in Practice - LLMs for causal inference 
 summary: >-
 
   Emre Kiciman, Senior Principal Researcher at Microsoft, talks about pywhy-llm, a new experimental library that focuses on using large language models for causality.
-  <br>
-  <br>
-  PyWhy Causality in Practice is a new talk series focusing on causality and machine learning, especially from a practical perspective. We'll have tutorials and presentations about PyWhy libraries but also talks by external speakers working on causal inference.
   <br>
   <br>
 

--- a/_community_videos/01_talk_series.md
+++ b/_community_videos/01_talk_series.md
@@ -1,15 +1,19 @@
 ---
-title: PyWhy Community Talk | LLMs for causal inference
+title: PyWhy Causality in Practice | LLMs for causal inference
 slug: pywhy-video
 layout: page
 description: >-
   PyWhy community Discord and meeting schedule. 
 summary: >-
-  Check out our latest video from our PyWhy community meeting
+
+  Emre Kiciman, Senior Principal Researcher at Microsoft, talks about pywhy-llm, a new experimental library that focuses on using large language models for causality.
+  <br>
+  <br>
+  PyWhy Causality in Practice is a new talk series focusing on causality and machine learning, especially from a practical perspective. We'll have tutorials and presentations about PyWhy libraries but also talks by external speakers working on causal inference.
   <br>
   <br>
 
-  <iframe width="800" height="450" src="https://www.youtube.com/embed/U9mJuUkhUzk?si=JHx2b2f0inFpwJ83" 
+  <iframe width="800" height="450" src="https://www.youtube.com/embed/1D5P7RVhHFU?si=LfA2XXHIhlsxJDBD" 
   title="YouTube video player" frameborder="0" allow="accelerometer; autoplay;
   clipboard-write; encrypted-media; gyroscope; picture-in-picture; 
   web-share" allowfullscreen></iframe>

--- a/_config.yml
+++ b/_config.yml
@@ -47,6 +47,10 @@ collections:
     output: false
     permalink: /:collection/:title
     sort_by: path
+  community_videos:
+    output: false
+    permalink: /:collection/:title
+    sort_by: path
 
 # Build settings
 markdown: kramdown

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -23,7 +23,17 @@
           </ul>
         </li>
         <li><a href="news.html">News</a></li>
-        <li><a href="community.html">Community</a></li>
+        <li>
+          <a href="community/discord.html" aria-haspopup="true"
+            >Community &#x25BE;</a
+          >
+          <ul class="dropdown" aria-label="submenu">
+            <li><a href="community/discord.html">Discord</a></li>
+            <li>
+              <a href="community/videos.html">Videos</a>
+            </li>
+          </ul>
+        </li>
         <li><a href="https://github.com/py-why" target="_blank">GitHub</a></li>
       </ul>
     </nav>

--- a/community-videos.md
+++ b/community-videos.md
@@ -1,0 +1,6 @@
+---
+layout: page
+permalink: community/videos.html
+---
+
+{% include articles.html collection="community_videos" %}

--- a/community.md
+++ b/community.md
@@ -1,5 +1,7 @@
 ---
 layout: page
+permalink: community/discord.html
+redirect_from: community.html
 ---
 
 {% include articles.html collection="community" %}


### PR DESCRIPTION
Makes community a dropdown with two pages:
1. Discord - Page describing the discord community
2. Videos - Page listing recent videos from the PyWhy talk series

Note, currently using placeholder youtube link, should replace with actual YouTube video of recent PyWhy talk

See screenshots:
<img width="332" alt="image" src="https://github.com/py-why/py-why.github.io/assets/22120253/c7a5ba3e-ab20-46b1-a428-dd0e2e431cd4">
<img width="1128" alt="image" src="https://github.com/py-why/py-why.github.io/assets/22120253/7bbf2684-29e6-4d63-a5f2-7d7c2620afc9">
<img width="1116" alt="image" src="https://github.com/py-why/py-why.github.io/assets/22120253/b27b5b20-6f34-43d5-b9fb-e36ba92b5937">
