### PR TITLE
add econml v0.15 youtube video

### DIFF
--- a/_community_videos/02_talk_series.md
+++ b/_community_videos/02_talk_series.md
@@ -1,0 +1,18 @@
+---
+title: EconML library and what's new in v0.15
+slug: pywhy-video
+layout: page
+description: >-
+  PyWhy Causality in Practice - EconML library and what's new in v0.15 
+summary: >-
+
+  EconML is a Python package that implements several cutting-edge causal inference estimators on top of flexible machine learning methods. In this talk, Keith Battocchi, software engineer at Microsoft Research New England and lead developer for EconML, presents a brief overview of EconML followed by a closer look at several big new features in EconML 0.15.
+  <br>
+  <br>
+
+  <iframe width="800" height="450" src="https://www.youtube.com/embed/66LBrNG2un0?si=6nDtEKbEDK5r_YFP" 
+  title="YouTube video player" frameborder="0" allow="accelerometer; autoplay;
+  clipboard-write; encrypted-media; gyroscope; picture-in-picture; 
+  web-share" allowfullscreen></iframe>
+
+---


### PR DESCRIPTION
Adds the most recent pywhy talk to the videos page. 

Screenshot below
<img width="955" alt="image" src="https://github.com/py-why/py-why.github.io/assets/22120253/3fbcd10f-a21a-4e9c-b1ce-f2277e92a3b6">
